### PR TITLE
Add ability to specify login/password for the Jenkins master

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Role Variables
 
     # Jenkins node vars
     jenkins_master_url: https://jenkins.mycompany.com/
+    jenkins_master_username: admin
+    jenkins_master_password: a63729ab56c0bcba03da92f2a6425c5a
     jenkins_node_executors: 2
     jenkins_node_host: jenkins-node-1.lan.mycompany.net (default: {{ ansible_eth0.ipv4.address }})
     jenkins_node_port: 22

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,8 @@ jenkins_username: jenkins
 
 # Jenkins node vars
 jenkins_master_url: null
+jenkins_master_username: ~
+jenkins_master_password: ~
 jenkins_node_credentials_id: null
 jenkins_node_executors: 2
 jenkins_node_host: null

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,6 +43,8 @@
 - name: Check previous node
   jenkins_api:
     jenkins_url: '{{ jenkins_master_url }}'
+    jenkins_username: '{{ jenkins_master_username }}'
+    jenkins_password: '{{ jenkins_master_password }}'
     command: node_exists
     args:
       - '{{ jenkins_node_name or ansible_hostname }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,6 +52,8 @@
 - name: Delete previous node
   jenkins_api:
     jenkins_url: '{{ jenkins_master_url }}'
+    jenkins_username: '{{ jenkins_master_username }}'
+    jenkins_password: '{{ jenkins_master_password }}'
     command: delete_node
     args:
       - '{{ jenkins_node_name or ansible_hostname }}'
@@ -62,6 +64,8 @@
 - name: Create jenkins node
   jenkins_api:
     jenkins_url: '{{ jenkins_master_url }}'
+    jenkins_username: '{{ jenkins_master_username }}'
+    jenkins_password: '{{ jenkins_master_password }}'
     command: create_node
     args:
       - '{{ jenkins_node_name or ansible_hostname }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,6 +40,12 @@
     user: '{{ jenkins_username }}'
     key: '{{ jenkins_authorized_key }}'
 
+- name: Ensure jenkins home belongs to the user
+  file:
+    path: '{{ jenkins_home }}'
+    owner: '{{ jenkins_username}}'
+    recurse: yes
+
 - name: Check previous node
   jenkins_api:
     jenkins_url: '{{ jenkins_master_url }}'


### PR DESCRIPTION
This is related to: https://github.com/novafloss/ansible-role-jenkins-api/pull/4
And would make no sense without it, obviously.