### PR TITLE
Make ca-certificates-java version customizable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,3 +12,6 @@ jenkins_node_host: null
 jenkins_node_port: 22
 jenkins_node_labels: null
 jenkins_node_name: null
+
+# packages versions
+ca_certificates_java: ca-certificates-java=20161107~bpo8+1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
     name: '{{ item }}'
     state: present
   with_items:
-    - ca-certificates-java=20161107~bpo8+1
+    - "{{ ca_certificates_java }}"
     - openjdk-8-jre-headless
     - sudo
 


### PR DESCRIPTION
So the installation can work on later debians.

ping @ewjoachim @toopy 